### PR TITLE
fix: Correctly get kaggle_output_filename

### DIFF
--- a/convert_to_kaggle_submission.py
+++ b/convert_to_kaggle_submission.py
@@ -19,7 +19,7 @@ label2idx = {
 def main(result_path):
     result = pd.read_csv(result_path, sep="\t")
     result["label"] = result["prediction"].map(lambda x: label2idx[x])
-    kaggle_output_filename = os.path.basename(result)
+    kaggle_output_filename = os.path.basename(result_path)
     result[["comments", "label"]].to_csv(
         f"{kaggle_dir}/{kaggle_output_filename}.csv", index=False
     )


### PR DESCRIPTION
Hi:)

For `os.path.basename()`, argument should be path, which is `str` type.

But it seems that `result` variable is given as an argument, which is `DataFrame` type. 

So I've changed it to `result_path` variable.

Below is the error log.

```bash
Traceback (most recent call last):
  File "convert_to_kaggle_submission.py", line 35, in <module>
    main(args.result_path)
  File "convert_to_kaggle_submission.py", line 22, in main
    kaggle_output_filename = os.path.basename(result)
  File "/home/ian/.pyenv/versions/3.6.9/lib/python3.6/posixpath.py", line 146, in basename
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not DataFrame
```